### PR TITLE
feat: Home Library Service: Part 2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+/dist
+/node_modules
+/database
+/test
+/doc
+.env
+.git
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+RUN npm cache clean --force
+
+COPY . .
+
+CMD [ "npm", "run", "start:dev" ]

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,0 +1,1 @@
+FROM postgres:16-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+networks:
+  default:
+    driver: bridge
+
+volumes:
+  database-postgres:
+
+services:
+  app:
+    container_name: hls-api-service
+    image: nickoff/hls-api
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - ${PORT}:${PORT}
+    restart: always
+    env_file:
+      - .env


### PR DESCRIPTION
### 1. Task: [link](https://github.com/AlreadyBored/nodejs-assignments/blob/main/assignments/containerization-database-orm/assignment.md)
### 2. Screenshot. 

### 3. Done 26.03.2024 / deadline 26.03.2024
### 4. Score: 0/ 360

#### Basic Scope

#### 1) Containerization, Docker

- **+20** `Readme.md` has instruction how to run application
- **+30** `user-defined bridge` is created and configured
- **+30**  container auto restart after crash
- **+20** application is restarting upon changes implemented into `src` folder
- **+30** database files and logs to be stored in volumes instead of container

#### 2) Database (PostgreSQL) & ORM

- **+20** `Users` data is stored in **PostgreSQL** database and `typeorm` / `prisma`  interacts with the database to manipulate data.  
- **+20** `Artists` data is stored in **PostgreSQL** database and `typeorm` / `prisma`  interacts with the database to manipulate data.
- **+20** `Albums` data is stored in **PostgreSQL** database and `typeorm` / `prisma`  interacts with the database to manipulate data.
- **+20** `Tracks` data is stored in **PostgreSQL** database and `typeorm` / `prisma`  interacts with the database to manipulate data.
- **+20** `Favorites` data is stored in **PostgreSQL** database and `typeorm` / `prisma`  interacts with the database to manipulate data.


#### Advanced Scope

#### 1) Containerization, Docker

- **+20** Final size of the Docker image with application is less than 500 MB
- **+10** Implemented npm script for vulnerabilities scanning (free solution)
- **+20** Your built image is pushed to DockerHub

#### 2) Database & ORM

- **+30** Migrations are used to create database entities 
- **+10** Variables used for connection to database to be stored in `.env`
- **+10** `typeorm` [decorators](https://typeorm.io/#/relations) or `prisma` relations create relations between entities
- **+30** Local **PostgreSQL** installation is not required for task check, connection is implemented to database stored in `docker` container  (on the basis of the previous task)